### PR TITLE
アプリ紹介ページをカード型グリッドレイアウトにリファクタリング。新しいAppCardコンポーネントを実装し、レスポンシブ対応（PC:3列、…

### DIFF
--- a/src/app/apps/page.tsx
+++ b/src/app/apps/page.tsx
@@ -1,8 +1,8 @@
 import { Metadata } from "next";
 import { PageHeader } from "@/components/common/PageHeader";
 import { AnimatedSection } from "@/components/common/AnimatedSection";
-import { ImageCarousel } from "@/components/common/ImageCarousel";
-import { getAllApps, type App } from "@/lib/data/apps-data";
+import { AppCard } from "@/components/apps/AppCard";
+import { getAllApps } from "@/lib/data/apps-data";
 
 export const metadata: Metadata = {
   title: "アプリ紹介 | AIビューティーサロン推進協会",
@@ -15,81 +15,6 @@ export const metadata: Metadata = {
   },
 };
 
-function AppCard({ app, index }: { app: App; index: number }) {
-  const isEven = index % 2 === 0;
-
-  return (
-    <AnimatedSection delay={index * 0.2} className="mb-16 lg:mb-24">
-      <div className="container mx-auto px-4">
-        <div className={`grid gap-8 lg:gap-12 items-center ${
-          isEven ? "lg:grid-cols-2" : "lg:grid-cols-2 lg:grid-flow-col-reverse"
-        }`}>
-          {/* テキストコンテンツ */}
-          <div className={isEven ? "lg:pr-8" : "lg:pl-8"}>
-            <h2 className="text-3xl lg:text-4xl font-bold text-gray-900 mb-4">
-              {app.name}
-            </h2>
-            
-            <p className="text-lg text-gray-600 mb-6 leading-relaxed">
-              {app.description}
-            </p>
-
-            {app.detailedDescription && (
-              <p className="text-gray-700 mb-6 leading-relaxed">
-                {app.detailedDescription}
-              </p>
-            )}
-
-            {app.features && app.features.length > 0 && (
-              <div className="mb-6">
-                <h3 className="text-lg font-semibold text-gray-900 mb-3">
-                  主な機能
-                </h3>
-                <div className="grid gap-2">
-                  {app.features.map((feature, featureIndex) => (
-                    <div key={featureIndex} className="flex items-center">
-                      <div className="w-2 h-2 bg-blue-500 rounded-full mr-3 flex-shrink-0" />
-                      <span className="text-gray-700">{feature}</span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            <div className="flex items-center space-x-2">
-              <span className="px-3 py-1 bg-blue-100 text-blue-800 text-sm font-medium rounded-full">
-                AI技術活用
-              </span>
-              <span className="px-3 py-1 border border-gray-300 text-gray-700 text-sm font-medium rounded-full">
-                効率化ソリューション
-              </span>
-            </div>
-          </div>
-
-          {/* スライドショー */}
-          <div className={isEven ? "lg:pl-8" : "lg:pr-8"}>
-            <div className="relative">
-              <div className="aspect-video rounded-lg overflow-hidden shadow-lg">
-                <ImageCarousel 
-                  slides={app.slides.map(slide => ({
-                    imageUrl: slide.imageUrl,
-                    altText: slide.altText
-                  }))}
-                  autoPlay={app.slides.length > 1}
-                  autoPlayInterval={4000}
-                />
-              </div>
-              
-              {/* 装飾要素 */}
-              <div className="absolute -top-4 -right-4 w-8 h-8 bg-blue-500 rounded-full opacity-20" />
-              <div className="absolute -bottom-4 -left-4 w-6 h-6 bg-green-500 rounded-full opacity-30" />
-            </div>
-          </div>
-        </div>
-      </div>
-    </AnimatedSection>
-  );
-}
 
 export default function AppsPage() {
   const apps = getAllApps();
@@ -119,41 +44,18 @@ export default function AppsPage() {
           </div>
         </AnimatedSection>
 
-        {/* アプリ一覧 */}
-        <div className="space-y-16 lg:space-y-24">
-          {apps.map((app, index) => (
-            <AppCard key={app.id} app={app} index={index} />
-          ))}
-        </div>
-
-        {/* CTA セクション */}
-        <AnimatedSection delay={0.4} className="mt-16 lg:mt-24">
-          <div className="container mx-auto px-4 text-center">
-            <div className="bg-white rounded-lg shadow-lg p-8 lg:p-12 max-w-4xl mx-auto">
-              <h2 className="text-2xl lg:text-3xl font-bold text-gray-900 mb-4">
-                アプリの導入をご検討ですか？
-              </h2>
-              <p className="text-lg text-gray-600 mb-8">
-                各アプリケーションの詳細な機能説明やデモンストレーション、
-                料金プランについては、お気軽にお問い合わせください。
-              </p>
-              <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                <a
-                  href="/contact"
-                  className="inline-flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 transition-colors"
-                >
-                  お問い合わせ
-                </a>
-                <a
-                  href="/pricing"
-                  className="inline-flex items-center justify-center px-6 py-3 border border-gray-300 text-base font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 transition-colors"
-                >
-                  料金プランを見る
-                </a>
-              </div>
+        {/* アプリ一覧 - カード型グリッドレイアウト */}
+        <AnimatedSection delay={0.2}>
+          <div className="container mx-auto px-4">
+            <div className="grid gap-6 lg:gap-8 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+              {apps.map((app, index) => (
+                <AppCard key={app.id} app={app} index={index} />
+              ))}
             </div>
           </div>
         </AnimatedSection>
+
+
       </main>
     </>
   );

--- a/src/components/apps/AppCard.tsx
+++ b/src/components/apps/AppCard.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { ImageCarousel } from "@/components/common/ImageCarousel";
+import { motion } from "framer-motion";
+import { type App } from "@/lib/data/apps-data";
+
+type AppCardProps = {
+  app: App;
+  index: number;
+};
+
+export function AppCard({ app, index }: AppCardProps) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // 特徴タグを抽出（最初の3つまで）
+  const featureTags = app.features?.slice(0, 3) || [];
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ 
+        duration: 0.5, 
+        delay: index * 0.1,
+        type: "spring",
+        stiffness: 300
+      }}
+      whileHover={{ y: -8, scale: 1.02 }}
+      className="h-full hover:shadow-xl transition-shadow duration-300"
+      style={{ WebkitTapHighlightColor: 'transparent' }}
+    >
+      <Card className="flex flex-col h-full overflow-hidden">
+        {/* アプリ画像 */}
+        <div className="relative aspect-video overflow-hidden">
+          <Image
+            src={app.slides[0].imageUrl}
+            alt={app.slides[0].altText}
+            fill
+            className="object-cover transition-transform duration-300 hover:scale-105"
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+          />
+          {/* グラデーションオーバーレイ */}
+          <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent" />
+        </div>
+
+        <CardHeader className="pb-4">
+          <CardTitle className="text-xl font-bold text-gray-900 leading-tight">
+            {app.name}
+          </CardTitle>
+          <CardDescription className="text-gray-600 text-sm leading-relaxed line-clamp-3">
+            {app.description}
+          </CardDescription>
+        </CardHeader>
+
+        <CardContent className="flex-grow pt-0">
+          {/* 特徴タグ */}
+          <div className="flex flex-wrap gap-2 mb-4">
+            {featureTags.map((feature, featureIndex) => (
+              <span
+                key={featureIndex}
+                className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-pink-100 text-pink-800 border border-pink-200"
+              >
+                {feature.length > 20 ? `${feature.substring(0, 20)}...` : feature}
+              </span>
+            ))}
+          </div>
+
+        </CardContent>
+
+        <CardFooter className="pt-4">
+          <Sheet open={isModalOpen} onOpenChange={setIsModalOpen}>
+            <SheetTrigger asChild>
+              <Button className="w-full" size="lg">
+                詳しく見る
+              </Button>
+            </SheetTrigger>
+            <SheetContent side="right" className="w-full sm:max-w-2xl overflow-y-auto">
+              <SheetHeader className="space-y-4 px-2">
+                <SheetTitle className="text-2xl font-bold text-left">
+                  {app.name}
+                </SheetTitle>
+                <SheetDescription className="text-left text-base text-gray-600">
+                  {app.description}
+                </SheetDescription>
+              </SheetHeader>
+              
+              <div className="mt-6 space-y-6 px-2">
+                {/* スライドショー */}
+                <div className="aspect-video rounded-lg overflow-hidden">
+                  <ImageCarousel 
+                    slides={app.slides.map(slide => ({
+                      imageUrl: slide.imageUrl,
+                      altText: slide.altText
+                    }))}
+                    autoPlay={app.slides.length > 1}
+                    autoPlayInterval={4000}
+                  />
+                </div>
+
+                {/* 詳細説明 */}
+                {app.detailedDescription && (
+                  <div>
+                    <h3 className="text-lg font-semibold text-gray-900 mb-3">
+                      詳細説明
+                    </h3>
+                    <p className="text-gray-700 leading-relaxed">
+                      {app.detailedDescription}
+                    </p>
+                  </div>
+                )}
+
+                {/* 主な機能 */}
+                {app.features && app.features.length > 0 && (
+                  <div>
+                    <h3 className="text-lg font-semibold text-gray-900 mb-3">
+                      主な機能・効果
+                    </h3>
+                    <div className="grid gap-3">
+                      {app.features.map((feature, featureIndex) => (
+                        <div key={featureIndex} className="flex items-start">
+                          <div className="w-2 h-2 bg-blue-500 rounded-full mr-3 flex-shrink-0 mt-2" />
+                          <span className="text-gray-700 text-sm leading-relaxed">
+                            {feature}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* CTA */}
+                <div className="bg-gray-50 rounded-lg p-6 text-center">
+                  <h4 className="font-semibold text-gray-900 mb-2">
+                    このアプリにご興味をお持ちですか？
+                  </h4>
+                  <p className="text-gray-600 text-sm mb-4">
+                    詳細な機能説明やデモンストレーションについては、お気軽にお問い合わせください。
+                  </p>
+                  <div className="flex flex-col sm:flex-row gap-3 justify-center">
+                    <Button asChild>
+                      <a href="/contact">お問い合わせ</a>
+                    </Button>
+                    <Button variant="outline" asChild>
+                      <a href="/pricing">料金プランを見る</a>
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            </SheetContent>
+          </Sheet>
+        </CardFooter>
+      </Card>
+    </motion.div>
+  );
+}


### PR DESCRIPTION
…タブレット:2列、モバイル:1列）でユーザビリティを大幅改善。詳細モーダル機能とframer-motionアニメーションも追加。

🤖 Generated with [Claude Code](https://claude.ai/code)